### PR TITLE
Add dev script and fix frontend proxy configuration

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -1,0 +1,56 @@
+const { spawn } = require('child_process');
+
+function start(name, command, args = [], options = {}) {
+  const proc = spawn(command, args, {
+    shell: true,
+    stdio: 'inherit',
+    ...options,
+  });
+  proc.on('exit', (code, signal) => {
+    console.log(`[${name}] exited with code ${code} signal ${signal}`);
+  });
+  proc.on('error', (err) => {
+    console.error(`[${name}] error:`, err);
+  });
+  return proc;
+}
+
+const children = [];
+
+// Start backend on 8081
+children.push(
+  start(
+    'backend',
+    'npm',
+    ['run', 'dev'],
+    { cwd: 'backend', env: { ...process.env, PORT: '8081' } }
+  )
+);
+
+// Start frontend on 8080
+children.push(
+  start(
+    'frontend',
+    'npm',
+    ['start'],
+    { cwd: 'frontend', env: { ...process.env, PORT: '8080' } }
+  )
+);
+
+function shutdown() {
+  console.log('Shutting down child processes...');
+  for (const child of children) {
+    if (child && !child.killed) {
+      try {
+        child.kill('SIGINT');
+      } catch {}
+    }
+  }
+  setTimeout(() => process.exit(0), 500);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+// Keep process alive
+setInterval(() => {}, 1 << 30);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,5 +74,5 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^3.1.1"
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "http://localhost:8081"
 }


### PR DESCRIPTION
## Purpose

Based on the conversation history, the users were working to set up a development environment for the Progress Tracker (Breast Cancer Patient Survey Analytics Platform). They needed to:
- Run the frontend on port 8080 and backend on port 8081
- Fix CORS policy violations between frontend and backend
- Streamline the development workflow

## Code changes

- **Added `dev.js`**: Created a development orchestration script that simultaneously starts both frontend (port 8080) and backend (port 8081) processes with proper process management and graceful shutdown handling
- **Fixed frontend proxy**: Updated `frontend/package.json` proxy configuration from `http://localhost:8080` to `http://localhost:8081` to correctly route API requests to the backend server

This resolves the CORS issues mentioned in the conversation and provides a single command to start the entire development environment.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c08ca85099dc4a61905841fa4fa83939/pulse-garden)

👀 [Preview Link](https://c08ca85099dc4a61905841fa4fa83939-pulse-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c08ca85099dc4a61905841fa4fa83939</projectId>-->
<!--<branchName>pulse-garden</branchName>-->